### PR TITLE
Update src_rag_hubspot.yml

### DIFF
--- a/models/staging/hubspot_staging/src_rag_hubspot.yml
+++ b/models/staging/hubspot_staging/src_rag_hubspot.yml
@@ -1,3 +1,5 @@
+version: 2
+
 sources:
   - name: rag_hubspot
     schema: "{{ var('rag_hubspot_schema', 'hubspot') }}"


### PR DESCRIPTION
Small PR to add a version tag to the HubSpot source.yml. While this isn't breaking `dbt run` commands, it is getting in the way of `dbt compile` commands and Quickstart auto deployments.