### PR TITLE
Fix append method to use 'do'

### DIFF
--- a/macros/staging/hubspot/get_macro_columns.sql
+++ b/macros/staging/hubspot/get_macro_columns.sql
@@ -2,7 +2,7 @@
 
     {%- set macro_column_names = [] -%}
     {%- for col in get_column_macro -%}
-        {%- set macro_column_names = macro_column_names.append(col.name | upper if target.type == 'snowflake' else col.name) -%}
+        {%- do macro_column_names.append(col.name | upper if target.type == 'snowflake' else col.name) -%}
     {%- endfor -%}
 
 {{ return(macro_column_names) }}


### PR DESCRIPTION
**Please provide your name and company**
Benoit Perigaud - dbt Labs

**Detail what changes this PR introduces and how this addresses the issue/feature request linked above.**

This PR fixes an issue for the package in Fusion.
While `set abc = abc.append(...)` is valid in dbt Core, it is not valid in Fusion (as `append` returns `None`) and the `do` approach is more idiomatic.

**How did you validate the changes introduced within this PR?**
I haven't in this case here, but we did the same fix in many other dbt projects